### PR TITLE
Align README to current api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Python interface with the squeezebox server using json-rpc
 
 ```
-from lms import find_server
-server = find_server()
+from lms import Server
+server = Server()
+server.update()
 print(server)
 
 192.168.0.81:9000 (7.9.0)


### PR DESCRIPTION
(Why has the find_server method been removed?)